### PR TITLE
Modify default genesis params for Panacea

### DIFF
--- a/types/staking.go
+++ b/types/staking.go
@@ -8,7 +8,7 @@ import (
 const (
 
 	// default bond denomination
-	DefaultBondDenom = "stake"
+	DefaultBondDenom = "umed"
 
 	// Delay, in blocks, between when validator updates are returned to the
 	// consensus-engine and when they are applied. For example, if

--- a/x/crisis/internal/types/genesis.go
+++ b/x/crisis/internal/types/genesis.go
@@ -21,7 +21,7 @@ func NewGenesisState(constantFee sdk.Coin) GenesisState {
 // DefaultGenesisState creates a default GenesisState object
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		ConstantFee: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1000)),
+		ConstantFee: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1000000000000)), // Spend 1,000,000 MED for invariants check
 	}
 }
 

--- a/x/distribution/types/genesis.go
+++ b/x/distribution/types/genesis.go
@@ -97,7 +97,7 @@ func NewGenesisState(feePool FeePool, communityTax, baseProposerReward, bonusPro
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
 		FeePool:                         InitialFeePool(),
-		CommunityTax:                    sdk.NewDecWithPrec(2, 2), // 2%
+		CommunityTax:                    sdk.ZeroDec(),
 		BaseProposerReward:              sdk.NewDecWithPrec(1, 2), // 1%
 		BonusProposerReward:             sdk.NewDecWithPrec(4, 2), // 4%
 		WithdrawAddrEnabled:             true,

--- a/x/gov/genesis.go
+++ b/x/gov/genesis.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Default period for deposits & voting
-	DefaultPeriod time.Duration = 86400 * 2 * time.Second // 2 days
+	DefaultPeriod time.Duration = 60 * 60 * 24 * 14 * time.Second // 14 days
 )
 
 // GenesisState - all staking state that must be provided at genesis

--- a/x/mint/internal/types/minter.go
+++ b/x/mint/internal/types/minter.go
@@ -30,10 +30,10 @@ func InitialMinter(inflation sdk.Dec) Minter {
 }
 
 // DefaultInitialMinter returns a default initial Minter object for a new chain
-// which uses an inflation rate of 13%.
+// which uses an inflation rate of 5.00%.
 func DefaultInitialMinter() Minter {
 	return InitialMinter(
-		sdk.NewDecWithPrec(13, 2),
+		sdk.NewDecWithPrec(5, 2),
 	)
 }
 

--- a/x/mint/internal/types/params.go
+++ b/x/mint/internal/types/params.go
@@ -49,11 +49,11 @@ func NewParams(mintDenom string, inflationRateChange, inflationMax,
 func DefaultParams() Params {
 	return Params{
 		MintDenom:           sdk.DefaultBondDenom,
-		InflationRateChange: sdk.NewDecWithPrec(13, 2),
-		InflationMax:        sdk.NewDecWithPrec(20, 2),
-		InflationMin:        sdk.NewDecWithPrec(7, 2),
+		InflationRateChange: sdk.NewDecWithPrec(2, 2),
+		InflationMax:        sdk.NewDecWithPrec(6, 2),
+		InflationMin:        sdk.NewDecWithPrec(4, 2),
 		GoalBonded:          sdk.NewDecWithPrec(67, 2),
-		BlocksPerYear:       uint64(60 * 60 * 8766 / 5), // assuming 5 second block times
+		BlocksPerYear:       uint64(60 * 60 * 24 * 365.25),  // assuming 1 second block time
 	}
 }
 

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -11,15 +11,15 @@ import (
 // Default parameter namespace
 const (
 	DefaultParamspace           = ModuleName
-	DefaultMaxEvidenceAge       = 60 * 2 * time.Second
-	DefaultSignedBlocksWindow   = int64(100)
+	DefaultMaxEvidenceAge       = 60 * 60 * 24 * 7 * 3 * time.Second // 3 weeks as same as unbonding period
+	DefaultSignedBlocksWindow   = int64(10000)
 	DefaultDowntimeJailDuration = 60 * 10 * time.Second
 )
 
 // The Double Sign Jail period ends at Max Time supported by Amino (Dec 31, 9999 - 23:59:59 GMT)
 var (
 	DoubleSignJailEndTime          = time.Unix(253402300799, 0)
-	DefaultMinSignedPerWindow      = sdk.NewDecWithPrec(5, 1)
+	DefaultMinSignedPerWindow      = sdk.NewDecWithPrec(5, 2)
 	DefaultSlashFractionDoubleSign = sdk.NewDec(1).Quo(sdk.NewDec(20))
 	DefaultSlashFractionDowntime   = sdk.NewDec(1).Quo(sdk.NewDec(100))
 )

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -18,7 +18,7 @@ const (
 	DefaultUnbondingTime time.Duration = time.Hour * 24 * 7 * 3
 
 	// Default maximum number of bonded validators
-	DefaultMaxValidators uint16 = 100
+	DefaultMaxValidators uint16 = 21
 
 	// Default maximum entries in a UBD/RED pair
 	DefaultMaxEntries uint16 = 7


### PR DESCRIPTION
Previously, these modifications have been done in the `panacea-core` ([app/genesis.go](https://github.com/medibloc/panacea-core/blob/40dbb0fd8e6d26efa426c118a8080a27d65de1a1/app/genesis.go#L219)).
I guess it's because Cosmos doesn't support the official way to override genesis params. They're saying that we must modify the `genesis.json` right after `panacead init [moniker]`, that is inconvenient.

But, for the Cosmos v0.37.14, many boilerplate codes in the `panacea-core` should be removed, because they were moved into the Cosmos.
In other words, the `app/genesis.go` should be deleted.

It means that we cannot set custom genesis params.
Please see details at https://github.com/medibloc/panacea-core/pull/58.

So, I modified params directly in this forked Cosmos.

-----------------------
FYI,
I also found this smart approach: https://github.com/desmos-labs/desmos/pull/58/files (by overriding the `DefaultGenesisState()`).
But, it didn't 100% work for Panacea, because some modules in the Cosmos doesn't allow overriding `DefaultGenesisState()` (such as `mint` and `gov`).
(because those modules don't have a `alias.go`.)

